### PR TITLE
Correctly check for config

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -42,5 +42,5 @@
 			"i18n"
 		]
 	},
-	"manifest_version": 1
+	"manifest_version": 2
 }

--- a/includes/FlickrImporter.php
+++ b/includes/FlickrImporter.php
@@ -52,8 +52,8 @@ class FlickrImporter {
 		$config = MediaWikiServices::getInstance()
 			->getConfigFactory()
 			->makeConfig( 'flickrimporter' );
-		if ( !$config->has( 'FlickrImporterKey' )
-			 || !$config->has( 'FlickrImporterSecret' )
+		if ( !$config->get( 'FlickrImporterKey' )
+			 || !$config->get( 'FlickrImporterSecret' )
 		) {
 			// Not configured.
 			return false;

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -10,6 +10,7 @@ namespace MediaWiki\Extension\FlickrImporter;
 
 use MediaWiki\MediaWikiServices;
 use Parser;
+use Samwilson\PhpFlickr\PhpFlickr;
 use SpecialPage;
 use Title;
 use User;
@@ -28,7 +29,7 @@ class Hooks {
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 
 		// Link to the Flickr connection process, or display current connection status.
-		$flickrUser = $flickr->test_login();
+		$flickrUser = $flickr instanceof PhpFlickr ? $flickr->test()->login() : false;
 		if ( $flickrUser ) {
 			// Connected.
 			$logoutLink = $linkRenderer->makeLink(


### PR DESCRIPTION
The config was not checking correctly for the absence of the
consumer key and secret.